### PR TITLE
fix: defer callback to prevent triggering resizeobserver loop limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "pretty-quick": "^2.0.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.0.0"
+    "react-test-renderer": "^16.0.0",
+    "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {
     "react": "^16.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -98,10 +98,13 @@ class ReactResizeObserver extends React.Component<ResizeObserverProps, ResizeObs
       this.setState(size);
 
       if (onResize) {
-        onResize({
-          ...size,
-          offsetWidth,
-          offsetHeight,
+        // defer the callback but not defer to next frame
+        Promise.resolve().then(() => {
+          onResize({
+            ...size,
+            offsetWidth,
+            offsetHeight,
+          });
         });
       }
     }

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import 'regenerator-runtime';
 import ResizeObserver from '../src';
 import { spyElementPrototype } from './utils/domHook';
 
@@ -80,7 +81,7 @@ describe('ResizeObserver', () => {
     });
   });
 
-  it('onResize', () => {
+  it('onResize', async () => {
     const onResize = jest.fn();
     const wrapper = mount(
       <ResizeObserver onResize={onResize}>
@@ -89,7 +90,7 @@ describe('ResizeObserver', () => {
     );
 
     wrapper.triggerResize();
-
+    await Promise.resolve();
     expect(wrapper.instance().currentElement).toBeTruthy();
     expect(onResize).toHaveBeenCalled();
   });


### PR DESCRIPTION
same issue as https://github.com/react-component/align/pull/72 