### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "cnpm": {
     "mode": "npm"


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
