### PR TITLE
fix: No-refable node should use `findDOMNode` also

### DIFF
--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -1,6 +1,9 @@
 import '../assets/index.less';
 import React from 'react';
-import ResizeObserver, { ResizeObserverProps } from '../src';
+import type { ResizeObserverProps } from '../src';
+import ResizeObserver from '../src';
+
+const Wrapper = ({ children }: any) => <>{children}</>;
 
 export default function App() {
   const [times, setTimes] = React.useState(0);
@@ -49,7 +52,9 @@ export default function App() {
           <span>Resize times: {times}</span>
         </div>
         <ResizeObserver onResize={onResize} disabled={disabled}>
-          <textarea ref={textareaRef} placeholder="I'm a textarea!" />
+          <Wrapper>
+            <textarea ref={textareaRef} placeholder="I'm a textarea!" />
+          </Wrapper>
         </ResizeObserver>
       </div>
     </React.StrictMode>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-resize-observer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Resize observer for React",
   "keywords": [
     "react",

--- a/src/SingleObserver/index.tsx
+++ b/src/SingleObserver/index.tsx
@@ -97,14 +97,13 @@ export default function SingleObserver(props: SingleObserverProps) {
   }, [elementRef.current, disabled]);
 
   // ============================ Render ============================
-  if (canRef) {
-    return (
-      <DomWrapper ref={wrapperRef}>
-        {React.cloneElement(children as any, {
-          ref: mergedRef,
-        })}
-      </DomWrapper>
-    );
-  }
-  return children;
+  return (
+    <DomWrapper ref={wrapperRef}>
+      {canRef
+        ? React.cloneElement(children as any, {
+            ref: mergedRef,
+          })
+        : children}
+    </DomWrapper>
+  );
 }

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -219,4 +219,22 @@ describe('ResizeObserver', () => {
       expect(errorSpy).not.toHaveBeenCalled();
     });
   });
+
+  it('should listen even not ref-able', async () => {
+    const Wrapper = props => <>{props.children}</>;
+    const onResize = jest.fn();
+
+    const wrapper = mount(
+      <ResizeObserver onResize={onResize}>
+        <Wrapper>
+          <div />
+        </Wrapper>
+      </ResizeObserver>,
+    );
+
+    wrapper.triggerResize();
+    await Promise.resolve();
+
+    expect(onResize).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
resolve https://github.com/react-component/resize-observer/issues/71