### PR TITLE
chore(deps): remove @types/classnames dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@rc-component/father-plugin": "^1.0.0",
     "@testing-library/react": "^12.1.5",
-    "@types/classnames": "^2.2.9",
     "@types/jest": "^29.5.10",
     "@types/react-dom": "^18.0.11",
     "@types/react": "^18.0.28",


### PR DESCRIPTION
classnames 2.3 开始已经自带 TypeScript 类型，@types/classnames 这个包不再需要