### PR TITLE
refactor: use rc-util getNodeRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.7",
     "classnames": "^2.2.1",
-    "rc-util": "^5.38.0",
+    "rc-util": "^5.44.1",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/src/SingleObserver/index.tsx
+++ b/src/SingleObserver/index.tsx
@@ -1,5 +1,5 @@
 import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
-import { supportRef, useComposeRef } from 'rc-util/lib/ref';
+import { supportRef, useComposeRef, getNodeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
 import type { ResizeObserverProps } from '..';
 import { CollectionContext } from '../Collection';
@@ -32,7 +32,7 @@ function SingleObserver(props: SingleObserverProps, ref: React.Ref<HTMLElement>)
   // ============================= Ref ==============================
   const canRef =
     !isRenderProps && React.isValidElement(mergedChildren) && supportRef(mergedChildren);
-  const originRef: React.Ref<Element> = canRef ? (mergedChildren as any).ref : null;
+  const originRef: React.Ref<Element> = canRef ? getNodeRef(mergedChildren) : null;
 
   const mergedRef = useComposeRef(originRef, elementRef);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `SingleObserver` 组件中的引用处理机制，提升了子组件的引用获取方式。

- **依赖更新**
	- 将 `rc-util` 依赖版本从 `^5.38.0` 更新至 `^5.44.1`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->