### PR TITLE
chore: use rc-component/util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ lib
 es
 yarn.lock
 package-lock.json
+pnpm-lock.yaml
 coverage/
 .doc
 # dumi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-resize-observer",
-  "version": "1.4.3",
+  "name": "@rc-component/resize-observer",
+  "version": "1.0.0",
   "description": "Resize observer for React",
   "keywords": [
     "react",
@@ -42,17 +42,18 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.7",
-    "classnames": "^2.2.1",
-    "rc-util": "^5.44.1",
-    "resize-observer-polyfill": "^1.5.1"
+    "@rc-component/util": "^1.2.0",
+    "classnames": "^2.2.1"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^1.0.0",
     "@testing-library/react": "^12.1.5",
     "@types/jest": "^29.5.10",
-    "@types/react-dom": "^18.0.11",
-    "@types/react": "^18.0.28",
+    "@types/node": "^22.10.7",
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.3",
     "@umijs/fabric": "^2.0.9",
+    "cheerio": "1.0.0-rc.12",
     "coveralls": "^3.0.6",
     "cross-env": "^7.0.2",
     "dumi": "^2.0.0",
@@ -69,7 +70,6 @@
     "rc-test": "^7.0.15",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "cheerio": "1.0.0-rc.12",
     "regenerator-runtime": "^0.14.0"
   },
   "peerDependencies": {

--- a/src/Collection.tsx
+++ b/src/Collection.tsx
@@ -14,13 +14,13 @@ export interface ResizeInfo {
 export interface CollectionProps {
   /** Trigger when some children ResizeObserver changed. Collect by frame render level */
   onBatchResize?: (resizeInfo: ResizeInfo[]) => void;
-  children?: React.ReactNode;
 }
 
 /**
  * Collect all the resize event from children ResizeObserver
  */
-export function Collection({ children, onBatchResize }: CollectionProps) {
+export const Collection: React.FC<React.PropsWithChildren<CollectionProps>> = props => {
+  const { children, onBatchResize } = props;
   const resizeIdRef = React.useRef(0);
   const resizeInfosRef = React.useRef<ResizeInfo[]>([]);
 
@@ -51,4 +51,4 @@ export function Collection({ children, onBatchResize }: CollectionProps) {
   );
 
   return <CollectionContext.Provider value={onResize}>{children}</CollectionContext.Provider>;
-}
+};

--- a/src/SingleObserver/DomWrapper.tsx
+++ b/src/SingleObserver/DomWrapper.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 
-export interface DomWrapperProps {
-  children: React.ReactElement;
-}
-
 /**
  * Fallback to findDOMNode if origin ref do not provide any dom element
  */
-export default class DomWrapper extends React.Component<DomWrapperProps> {
+class DomWrapper extends React.Component<React.PropsWithChildren> {
   render() {
     return this.props.children;
   }
 }
+
+export default DomWrapper;

--- a/src/SingleObserver/index.tsx
+++ b/src/SingleObserver/index.tsx
@@ -1,5 +1,5 @@
-import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
-import { supportRef, useComposeRef, getNodeRef } from 'rc-util/lib/ref';
+import findDOMNode from '@rc-component/util/lib/Dom/findDOMNode';
+import { supportRef, useComposeRef, getNodeRef } from '@rc-component/util/lib/ref';
 import * as React from 'react';
 import type { ResizeObserverProps } from '..';
 import { CollectionContext } from '../Collection';
@@ -10,7 +10,10 @@ export interface SingleObserverProps extends ResizeObserverProps {
   children: React.ReactElement | ((ref: React.RefObject<Element>) => React.ReactElement);
 }
 
-function SingleObserver(props: SingleObserverProps, ref: React.Ref<HTMLElement>) {
+const SingleObserver: React.ForwardRefRenderFunction<HTMLElement, SingleObserverProps> = (
+  props,
+  ref,
+) => {
   const { children, disabled } = props;
   const elementRef = React.useRef<Element>(null);
   const wrapperRef = React.useRef<DomWrapper>(null);
@@ -32,7 +35,8 @@ function SingleObserver(props: SingleObserverProps, ref: React.Ref<HTMLElement>)
   // ============================= Ref ==============================
   const canRef =
     !isRenderProps && React.isValidElement(mergedChildren) && supportRef(mergedChildren);
-  const originRef: React.Ref<Element> = canRef ? getNodeRef(mergedChildren) : null;
+
+  const originRef: React.Ref<Element> = canRef ? getNodeRef(mergedChildren as any) : null;
 
   const mergedRef = useComposeRef(originRef, elementRef);
 
@@ -42,7 +46,7 @@ function SingleObserver(props: SingleObserverProps, ref: React.Ref<HTMLElement>)
     (elementRef.current && typeof elementRef.current === 'object'
       ? findDOMNode<HTMLElement>((elementRef.current as any)?.nativeElement)
       : null) ||
-    findDOMNode<HTMLElement>(wrapperRef.current);
+    findDOMNode<HTMLElement>(wrapperRef.current as any);
 
   React.useImperativeHandle(ref, () => getDom());
 
@@ -110,14 +114,10 @@ function SingleObserver(props: SingleObserverProps, ref: React.Ref<HTMLElement>)
   // ============================ Render ============================
   return (
     <DomWrapper ref={wrapperRef}>
-      {canRef
-        ? React.cloneElement(mergedChildren as any, {
-            ref: mergedRef,
-          })
-        : mergedChildren}
+      {canRef ? React.cloneElement<any>(mergedChildren, { ref: mergedRef }) : mergedChildren}
     </DomWrapper>
   );
-}
+};
 
 const RefSingleObserver = React.forwardRef(SingleObserver);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,13 +49,13 @@ const ResizeObserver: React.ForwardRefRenderFunction<HTMLElement, ResizeObserver
   }
 
   return childNodes.map((child, index) => {
-    const key = child?.key || `${INTERNAL_PREFIX_KEY}-${index}`;
+    const key = child?.key ?? `${INTERNAL_PREFIX_KEY}-${index}`;
     return (
       <SingleObserver {...props} key={key} ref={index === 0 ? ref : undefined}>
         {child}
       </SingleObserver>
     );
-  });
+  }) as any as React.ReactElement;
 };
 
 const RefResizeObserver = React.forwardRef(ResizeObserver) as React.ForwardRefExoticComponent<

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import toArray from 'rc-util/lib/Children/toArray';
-import { warning } from 'rc-util/lib/warning';
+import toArray from '@rc-component/util/lib/Children/toArray';
+import { warning } from '@rc-component/util/lib/warning';
 import SingleObserver from './SingleObserver';
 import { Collection } from './Collection';
 
@@ -30,9 +30,12 @@ export interface ResizeObserverProps {
   onResize?: OnResize;
 }
 
-function ResizeObserver(props: ResizeObserverProps, ref: React.Ref<HTMLElement>) {
+const ResizeObserver: React.ForwardRefRenderFunction<HTMLElement, ResizeObserverProps> = (
+  props,
+  ref,
+) => {
   const { children } = props;
-  const childNodes = typeof children === 'function' ? [children] : toArray(children);
+  const childNodes = typeof children === 'function' ? [children] : toArray(children as any);
 
   if (process.env.NODE_ENV !== 'production') {
     if (childNodes.length > 1) {
@@ -52,8 +55,8 @@ function ResizeObserver(props: ResizeObserverProps, ref: React.Ref<HTMLElement>)
         {child}
       </SingleObserver>
     );
-  }) as any as React.ReactElement;
-}
+  });
+};
 
 const RefResizeObserver = React.forwardRef(ResizeObserver) as React.ForwardRefExoticComponent<
   React.PropsWithoutRef<ResizeObserverProps> & React.RefAttributes<any>

--- a/src/utils/observerUtil.ts
+++ b/src/utils/observerUtil.ts
@@ -1,5 +1,3 @@
-import ResizeObserver from 'resize-observer-polyfill';
-
 export type ResizeListener = (element: Element) => void;
 
 // =============================== Const ===============================
@@ -12,8 +10,7 @@ function onResize(entities: ResizeObserverEntry[]) {
   });
 }
 
-// Note: ResizeObserver polyfill not support option to measure border-box resize
-const resizeObserver = new ResizeObserver(onResize);
+const resizeObserver = 'ResizeObserver' in window ? new ResizeObserver(onResize) : undefined;
 
 // Dev env only
 export const _el = process.env.NODE_ENV !== 'production' ? elementListeners : null; // eslint-disable-line
@@ -25,7 +22,6 @@ export function observe(element: Element, callback: ResizeListener) {
     elementListeners.set(element, new Set());
     resizeObserver.observe(element);
   }
-
   elementListeners.get(element).add(callback);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **依赖变更**
	- 包名从 `rc-resize-observer` 更新为 `@rc-component/resize-observer`
	- 版本从 `1.4.3` 降至 `1.0.0`
	- 移除 `rc-util` 和 `resize-observer-polyfill` 依赖
	- 添加 `@rc-component/util` 依赖

- **代码重构**
	- 更新多个组件的函数签名和类型定义
	- 优化 React 组件的 props 处理方式
	- 调整导入路径和依赖引用

- **其他变更**
	- 更新 TypeScript 类型依赖版本
	- 调整 `.gitignore` 文件，忽略 `pnpm-lock.yaml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->