### PR TITLE
docs: fix online link error open

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Resize observer for React.
 
 ## Live Demo
 
-https://react-component.github.io/resize-observer/
+https://resize-observer-react-component.vercel.app/
 
 ## Install
 


### PR DESCRIPTION
docs: resize-observer live link can not open with github.io  replace with vercel link

![image](https://github.com/user-attachments/assets/b06aa469-9158-4725-8ffc-8e8f217f4df3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
	- 更新了项目的演示站点 URL，现在指向新的部署地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->