### PR TITLE
Avoid deep imports and migrate tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
   setupFiles: ['./tests/setup.js'],
-  snapshotSerializers: [require.resolve('enzyme-to-json/serializer')],
 };

--- a/package.json
+++ b/package.json
@@ -41,24 +41,21 @@
     "now-build": "npm run build"
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.0"
+    "@rc-component/util": "^1.11.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.10",
     "@types/node": "^24.5.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@umijs/fabric": "^4.0.0",
-    "cheerio": "1.0.0-rc.12",
     "coveralls": "^3.0.6",
     "cross-env": "^7.0.2",
     "dumi": "^2.0.0",
-    "enzyme": "^3.0.0",
-    "enzyme-adapter-react-16": "^1.15.6",
-    "enzyme-to-json": "^3.4.0",
+    "eslint": "8.x",
     "father": "^4.0.0",
     "gh-pages": "^6.1.0",
     "glob": "^7.1.6",
@@ -66,10 +63,8 @@
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0",
     "rc-test": "^7.0.15",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "regenerator-runtime": "^0.14.0",
-    "eslint": "8.x"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0",

--- a/src/SingleObserver/index.tsx
+++ b/src/SingleObserver/index.tsx
@@ -1,5 +1,4 @@
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import { supportRef, useComposeRef, getNodeRef } from '@rc-component/util/lib/ref';
+import { getDOM, getNodeRef, supportRef, useComposeRef } from '@rc-component/util';
 import * as React from 'react';
 import type { ResizeObserverProps } from '..';
 import { CollectionContext } from '../Collection';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import toArray from '@rc-component/util/lib/Children/toArray';
-import { warning } from '@rc-component/util/lib/warning';
+import { toArray, warning } from '@rc-component/util';
 import SingleObserver from './SingleObserver';
 import { Collection } from './Collection';
 

--- a/tests/Collection.spec.js
+++ b/tests/Collection.spec.js
@@ -1,8 +1,9 @@
+import { render } from '@testing-library/react';
 import React from 'react';
-import { mount } from 'enzyme';
-import 'regenerator-runtime';
-import ResizeObserver from '../src';
+import ResizeObserver, { _rs as triggerResize } from '../src';
 import { spyElementPrototypes } from './utils/domHook';
+
+const waitPromise = () => Promise.resolve();
 
 describe('ResizeObserver.Collection', () => {
   let domSpy;
@@ -33,7 +34,7 @@ describe('ResizeObserver.Collection', () => {
   it('batch collection', async () => {
     const onBatchResize = jest.fn();
 
-    const wrapper = mount(
+    const { container } = render(
       <ResizeObserver.Collection onBatchResize={onBatchResize}>
         <ResizeObserver>
           <div id="div1" />
@@ -44,29 +45,31 @@ describe('ResizeObserver.Collection', () => {
       </ResizeObserver.Collection>,
     );
 
+    const div1 = container.querySelector('#div1');
+    const div2 = container.querySelector('#div2');
+
+    await waitPromise();
+    onBatchResize.mockReset();
+
     // Resize div1
-    wrapper.triggerResize(0);
-    await Promise.resolve();
-    expect(onBatchResize).toHaveBeenCalledWith([
-      expect.objectContaining({ element: wrapper.find('#div1').getDOMNode() }),
-    ]);
+    triggerResize([{ target: div1 }]);
+    await waitPromise();
+    expect(onBatchResize).toHaveBeenCalledWith([expect.objectContaining({ element: div1 })]);
 
     // Resize both
     onBatchResize.mockReset();
-    wrapper.triggerResize(0);
-    wrapper.triggerResize(1);
-    await Promise.resolve();
+    triggerResize([{ target: div1 }]);
+    triggerResize([{ target: div2 }]);
+    await waitPromise();
     expect(onBatchResize).toHaveBeenCalledWith([
-      expect.objectContaining({ element: wrapper.find('#div1').getDOMNode() }),
-      expect.objectContaining({ element: wrapper.find('#div2').getDOMNode() }),
+      expect.objectContaining({ element: div1 }),
+      expect.objectContaining({ element: div2 }),
     ]);
 
     // Resize div2
     onBatchResize.mockReset();
-    wrapper.triggerResize(1);
-    await Promise.resolve();
-    expect(onBatchResize).toHaveBeenCalledWith([
-      expect.objectContaining({ element: wrapper.find('#div2').getDOMNode() }),
-    ]);
+    triggerResize([{ target: div2 }]);
+    await waitPromise();
+    expect(onBatchResize).toHaveBeenCalledWith([expect.objectContaining({ element: div2 })]);
   });
 });

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,9 +1,10 @@
+import { render } from '@testing-library/react';
 import React from 'react';
-import { mount } from 'enzyme';
-import 'regenerator-runtime';
-import ResizeObserver from '../src';
-import { spyElementPrototypes } from './utils/domHook';
+import ResizeObserver, { _rs as triggerResize } from '../src';
 import { _el as elementListeners } from '../src/utils/observerUtil';
+import { spyElementPrototypes } from './utils/domHook';
+
+const waitPromise = () => Promise.resolve();
 
 describe('ResizeObserver', () => {
   let errorSpy;
@@ -40,7 +41,7 @@ describe('ResizeObserver', () => {
 
   describe('children count warning', () => {
     it('without children', () => {
-      mount(<ResizeObserver />);
+      render(<ResizeObserver />);
 
       expect(errorSpy).toHaveBeenCalledWith(
         'Warning: `children` of ResizeObserver is empty. Nothing is in observe.',
@@ -48,9 +49,9 @@ describe('ResizeObserver', () => {
     });
 
     it('multiple children', () => {
-      const wrapper = mount(
+      const { container } = render(
         <ResizeObserver>
-          <div key="exist-key" />
+          <div data-name="first" key="exist-key" />
           <div />
         </ResizeObserver>,
       );
@@ -59,14 +60,14 @@ describe('ResizeObserver', () => {
         'Warning: Find more than one child node with `children` in ResizeObserver. Please use ResizeObserver.Collection instead.',
       );
 
-      expect(wrapper.find('div').first().key()).toEqual('exist-key');
+      expect(container.querySelector('div')?.getAttribute('data-name')).toEqual('first');
     });
   });
 
   describe('child ref should support', () => {
     it('function', () => {
       const refFunc = jest.fn();
-      mount(
+      render(
         <ResizeObserver>
           <div ref={refFunc} />
         </ResizeObserver>,
@@ -77,7 +78,7 @@ describe('ResizeObserver', () => {
 
     it('object', () => {
       const ref = React.createRef();
-      mount(
+      render(
         <ResizeObserver>
           <div ref={ref} />
         </ResizeObserver>,
@@ -90,14 +91,14 @@ describe('ResizeObserver', () => {
   describe('onResize', () => {
     it('basic', async () => {
       const onResize = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <ResizeObserver onResize={onResize}>
           <div />
         </ResizeObserver>,
       );
 
-      wrapper.triggerResize();
-      await Promise.resolve();
+      triggerResize([{ target: container.firstElementChild }]);
+      await waitPromise();
       expect(onResize).toHaveBeenCalled();
     });
 
@@ -108,26 +109,26 @@ describe('ResizeObserver', () => {
       mockOffsetWidth = 0;
 
       const onResize = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <ResizeObserver onResize={onResize}>
           <div />
         </ResizeObserver>,
       );
 
       // Init
-      wrapper.triggerResize();
-      await Promise.resolve();
+      triggerResize([{ target: container.firstElementChild }]);
+      await waitPromise();
       onResize.mockReset();
 
       // Not trigger when not change
-      wrapper.triggerResize();
-      await Promise.resolve();
+      triggerResize([{ target: container.firstElementChild }]);
+      await waitPromise();
       expect(onResize).not.toHaveBeenCalled();
 
       // Trigger when offset changed
       mockOffsetWidth = 1023;
-      wrapper.triggerResize();
-      await Promise.resolve();
+      triggerResize([{ target: container.firstElementChild }]);
+      await waitPromise();
       expect(onResize).toHaveBeenCalled();
     });
 
@@ -138,14 +139,14 @@ describe('ResizeObserver', () => {
       mockOffsetWidth = 10;
 
       const onResize = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <ResizeObserver onResize={onResize}>
           <div />
         </ResizeObserver>,
       );
 
-      wrapper.triggerResize();
-      await Promise.resolve();
+      triggerResize([{ target: container.firstElementChild }]);
+      await waitPromise();
 
       expect(onResize).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -157,34 +158,38 @@ describe('ResizeObserver', () => {
   });
 
   it('disabled should not trigger onResize', () => {
-    const wrapper = mount(
+    const { container, rerender } = render(
       <ResizeObserver>
         <div />
       </ResizeObserver>,
     );
 
-    wrapper.setProps({ disabled: true });
-    expect(elementListeners.get(wrapper.getDOMNode())).toBeFalsy();
+    rerender(
+      <ResizeObserver disabled>
+        <div />
+      </ResizeObserver>,
+    );
+    expect(elementListeners.get(container.firstElementChild)).toBeFalsy();
   });
 
   it('unmount to clear', () => {
-    const wrapper = mount(
+    const { container, unmount } = render(
       <ResizeObserver>
         <div />
       </ResizeObserver>,
     );
-    const dom = wrapper.getDOMNode();
+    const dom = container.firstElementChild;
     expect(elementListeners.get(dom)).toBeTruthy();
 
     // Unmount
-    wrapper.unmount();
+    unmount();
     expect(elementListeners.get(dom)).toBeFalsy();
   });
 
   describe('work with child type', () => {
     it('function component', () => {
       const FC = () => <div />;
-      mount(
+      render(
         <ResizeObserver>
           <FC />
         </ResizeObserver>,
@@ -194,7 +199,7 @@ describe('ResizeObserver', () => {
 
     it('forwardRef function component', () => {
       const FRC = React.forwardRef(() => <div />);
-      mount(
+      render(
         <ResizeObserver>
           <FRC />
         </ResizeObserver>,
@@ -210,7 +215,7 @@ describe('ResizeObserver', () => {
           return null;
         }
       }
-      mount(
+      render(
         <ResizeObserver>
           <CC />
         </ResizeObserver>,
@@ -223,7 +228,7 @@ describe('ResizeObserver', () => {
     const Wrapper = props => <>{props.children}</>;
     const onResize = jest.fn();
 
-    const wrapper = mount(
+    const { container } = render(
       <ResizeObserver onResize={onResize}>
         <Wrapper>
           <div />
@@ -231,30 +236,30 @@ describe('ResizeObserver', () => {
       </ResizeObserver>,
     );
 
-    wrapper.triggerResize();
-    await Promise.resolve();
+    triggerResize([{ target: container.querySelector('div') }]);
+    await waitPromise();
 
     expect(onResize).not.toHaveBeenCalled();
   });
 
   it('support renderProps', () => {
-    const wrapper = mount(
+    const { container } = render(
       <ResizeObserver>{ref => <div ref={ref} className="block" />}</ResizeObserver>,
     );
 
-    expect(wrapper.exists('.block')).toBeTruthy();
+    expect(container.querySelector('.block')).toBeTruthy();
   });
 
   it('ref-able', () => {
     const domRef = React.createRef();
 
-    const wrapper = mount(
+    const { container } = render(
       <ResizeObserver ref={domRef}>
         <div className="block" />
       </ResizeObserver>,
     );
 
     expect(domRef.current instanceof HTMLDivElement).toBeTruthy();
-    expect(domRef.current).toBe(wrapper.find('div.block').getDOMNode());
+    expect(domRef.current).toBe(container.querySelector('div.block'));
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,19 +1,3 @@
-const Enzyme = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-const { _rs: onResize } = require('../src/utils/observerUtil');
-
-Enzyme.configure({ adapter: new Adapter() });
-
-Object.assign(Enzyme.ReactWrapper.prototype, {
-  findObserver(index = 0) {
-    return this.find('ResizeObserver').at(index);
-  },
-  triggerResize(index = 0) {
-    const target = this.findObserver(index).getDOMNode();
-    onResize([{ target }]);
-  },
-});
-
 // Mock for ResizeObserver
 global.ResizeObserver = class ResizeObserver {
   constructor(callback) {


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到包含根入口导出的版本，并升级 `@rc-component/father-plugin`。
- 将 `@rc-component/util/lib/...` 深路径导入调整为从 `@rc-component/util` 根入口导入。
- 将剩余 Enzyme 测试迁移到 Testing Library。
- 移除 `enzyme`、`enzyme-adapter-react-16`、`enzyme-to-json`、`cheerio`、`regenerator-runtime` 和 enzyme snapshot serializer/setup 配置。
- 测试环境 dev 依赖对齐到 React 18，运行时 `peerDependencies` 保持不变。

## 验证

- `npm test -- --runInBand` 通过。
- `npm run lint` 通过，保留既有 `react-hooks/exhaustive-deps` warning。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级 React 支持版本至 18.0，更新相关依赖包至最新兼容版本
  * 更新测试工具链依赖，替换测试框架以适应新版本

* **Tests**
  * 迁移测试用例至新的测试框架，确保测试覆盖率与执行效果一致

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/resize-observer/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->